### PR TITLE
Enable restrictions based on mod id/prefix

### DIFF
--- a/common/src/main/java/net/impleri/blockskills/BlockEvents.java
+++ b/common/src/main/java/net/impleri/blockskills/BlockEvents.java
@@ -2,11 +2,14 @@ package net.impleri.blockskills;
 
 import dev.architectury.event.EventResult;
 import dev.architectury.event.events.common.InteractionEvent;
+import dev.architectury.event.events.common.LifecycleEvent;
 import dev.architectury.event.events.common.PlayerEvent;
+import dev.architectury.platform.Platform;
 import net.impleri.blockskills.api.Restrictions;
 import net.impleri.playerskills.server.events.SkillChangedEvent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
@@ -15,11 +18,21 @@ import java.util.HashMap;
 
 public class BlockEvents {
     public void registerEventHandlers() {
-        InteractionEvent.LEFT_CLICK_BLOCK.register(this::beforeMineBlock);
-        InteractionEvent.RIGHT_CLICK_BLOCK.register(this::beforeUseItemBlock);
+        LifecycleEvent.SERVER_STARTING.register(this::onStartup);
+
         PlayerEvent.PLAYER_JOIN.register(this::onJoin);
         PlayerEvent.PLAYER_QUIT.register(this::onQuit);
+
+        InteractionEvent.LEFT_CLICK_BLOCK.register(this::beforeMineBlock);
+        InteractionEvent.RIGHT_CLICK_BLOCK.register(this::beforeUseItemBlock);
+        
         SkillChangedEvent.EVENT.register(this::onSkillChanged);
+    }
+
+    private void onStartup(MinecraftServer minecraftServer) {
+        if (Platform.isModLoaded("kubejs")) {
+            net.impleri.blockskills.integrations.kubejs.BlockSkillsPlugin.onStartup();
+        }
     }
 
     private EventResult beforeMineBlock(Player player, InteractionHand hand, BlockPos pos, Direction face) {

--- a/common/src/main/java/net/impleri/blockskills/integrations/kubejs/BlockSkillsPlugin.java
+++ b/common/src/main/java/net/impleri/blockskills/integrations/kubejs/BlockSkillsPlugin.java
@@ -11,13 +11,8 @@ public class BlockSkillsPlugin extends KubeJSPlugin {
         EventsBinding.GROUP.register();
     }
 
-    @Override
-    public void initStartup() {
+    public static void onStartup() {
         Registry.INSTANCE.clear();
-        loadRestrictions();
-    }
-
-    private void loadRestrictions() {
         EventsBinding.RESTRICTIONS.post(new RestrictionsRegistrationEventJS());
     }
 }

--- a/common/src/main/java/net/impleri/blockskills/integrations/kubejs/events/EventsBinding.java
+++ b/common/src/main/java/net/impleri/blockskills/integrations/kubejs/events/EventsBinding.java
@@ -6,5 +6,5 @@ import dev.latvian.mods.kubejs.event.EventHandler;
 public abstract class EventsBinding {
     public static final EventGroup GROUP = EventGroup.of("BlockSkillEvents");
 
-    public static final EventHandler RESTRICTIONS = GROUP.startup("register", () -> RestrictionsRegistrationEventJS.class);
+    public static final EventHandler RESTRICTIONS = GROUP.server("register", () -> RestrictionsRegistrationEventJS.class);
 }

--- a/common/src/main/java/net/impleri/blockskills/integrations/kubejs/events/RestrictionsRegistrationEventJS.java
+++ b/common/src/main/java/net/impleri/blockskills/integrations/kubejs/events/RestrictionsRegistrationEventJS.java
@@ -2,29 +2,50 @@ package net.impleri.blockskills.integrations.kubejs.events;
 
 import dev.latvian.mods.kubejs.event.EventJS;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import net.impleri.blockskills.BlockHelper;
-import net.impleri.blockskills.BlockSkills;
 import net.impleri.blockskills.restrictions.Registry;
 import net.impleri.playerskills.utils.SkillResourceLocation;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
 
 public class RestrictionsRegistrationEventJS extends EventJS {
-    public void restrict(String blockName, @NotNull Consumer<RestrictionJS.Builder> consumer) {
-        var name = SkillResourceLocation.of(blockName);
+    public void restrict(String name, @NotNull Consumer<RestrictionJS.Builder> consumer) {
+        if (name.trim().endsWith(":*")) {
+            var namespace = name.substring(0, name.indexOf(":"));
+
+            restrictNamespace(namespace, consumer);
+            return;
+        }
+
+        var blockName = SkillResourceLocation.of(name);
+        restrictBlock(blockName, consumer);
+    }
+
+    @HideFromJS
+    public void restrictBlock(ResourceLocation name, @NotNull Consumer<RestrictionJS.Builder> consumer) {
         var builder = new RestrictionJS.Builder(name);
 
         consumer.accept(builder);
 
         var block = BlockHelper.getBlock(name);
         if (BlockHelper.isEmptyBlock(block)) {
-            BlockSkills.LOGGER.warn("Could not find any block named %s", name);
+            ConsoleJS.SERVER.warn("Could not find any block named " + name);
             return;
         }
 
         var restriction = builder.createObject(block.defaultBlockState());
-        ConsoleJS.STARTUP.info("Created block restriction for " + blockName);
+        ConsoleJS.SERVER.info("Created block restriction for " + name);
         Registry.INSTANCE.add(name, restriction);
+    }
+
+    @HideFromJS
+    private void restrictNamespace(String namespace, @NotNull Consumer<RestrictionJS.Builder> consumer) {
+        net.minecraft.core.Registry.BLOCK.keySet()
+                .stream()
+                .filter(blockName -> blockName.getNamespace().equals(namespace))
+                .forEach(blockName -> restrictBlock(blockName, consumer));
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ forge_version=1.19.2-43.2.0
 kubejs_version=1902.6.0-build.142
 rhino_version=1902.2.2-build.264
 # PlayerSkills dependency
-playerskills_version=1.5.0
+playerskills_version=1.5.1

--- a/readme.md
+++ b/readme.md
@@ -46,16 +46,20 @@ meets that condition. By default, no restrictions are set, so be sure to set act
 ### Examples
 
 ```js
-  // Coal ore blocks cannot be mined and won't drop anything if player is at stage 1 or below
 BlockSkillEvents.register(event => {
+  // Vanilla MC blocks won't drop anything if player is at stage 1 or below
+  event.restrict(
+    'minecraft:*',
+    r => r.unharvestable().if(player => player.cannot('skills:stage', 2))
+  );
+
+  // Coal ore blocks cannot be mined and won't drop anything if player is at stage 1 or below
   event.restrict(
     'minecraft:coal_ore',
     r => r.everything().if(player => player.cannot('skills:stage', 2))
   );
-});
 
-// Iron ore blocks will look and act like stone
-ItemSkillEvents.register(event => {
+  // Iron ore blocks will look and act like stone
   event.restrict(
     'minecraft:iron_ore',
     r => r.replaceWithBlock('minecraft:stone').unless(player => player.can('skills:stage', 2))


### PR DESCRIPTION
FEATURES

Target blocks belonging to a mod using the `modid:*` selector (e.g. `minecraft:*` will target every vanilla MC block).

BREAKING CHANGES

BlockSkillEvents.register is now a `server` script (vs `startup`) to ensure blocks are registered before restrictions take place.