### PR TITLE
fix: Keep original blockState if not replaced

### DIFF
--- a/common/src/main/java/net/impleri/blockskills/BlockHelper.java
+++ b/common/src/main/java/net/impleri/blockskills/BlockHelper.java
@@ -90,9 +90,10 @@ public class BlockHelper {
 
         if (isReplacedBlock(original, replacement)) {
             BlockSkills.LOGGER.debug("Replacement for {} is {}", getBlockName(original), getBlockName(replacement));
+            return replacement.defaultBlockState();
         }
 
-        return replacement.defaultBlockState();
+        return original;
     }
 
     // Used in mixins for detecting if the block should burn


### PR DESCRIPTION
Backport of #29 to 1.18.2